### PR TITLE
Add sample program explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# ASSC-2025
+# ASSC-2025 Program Explorer
+
+This repository contains a small single-page web application for exploring a sample program schedule for ASSC 2025. The app loads data from `program.json` and allows filtering by day, session type and session name.
+
+## Usage
+
+Open `index.html` in a modern web browser. No build steps are required.
+
+The dataset in `program.json` contains example sessions and presentations. Replace it with real data as needed.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,84 @@
+let sessionsData = [];
+
+async function loadData() {
+    try {
+        const response = await fetch('program.json');
+        sessionsData = await response.json();
+        populateFilters();
+        renderSessions();
+    } catch (error) {
+        document.getElementById('sessions').textContent = 'Failed to load program data.';
+    }
+}
+
+function populateFilters() {
+    const daySelect = document.getElementById('day-select');
+    const typeSelect = document.getElementById('type-select');
+    const sessionSelect = document.getElementById('session-select');
+
+    const days = [...new Set(sessionsData.map(s => s.day))];
+    const types = [...new Set(sessionsData.map(s => s.type))];
+    const names = [...new Set(sessionsData.map(s => s.session))];
+
+    for (const d of days) {
+        const opt = document.createElement('option');
+        opt.value = d;
+        opt.textContent = d;
+        daySelect.appendChild(opt);
+    }
+
+    for (const t of types) {
+        const opt = document.createElement('option');
+        opt.value = t;
+        opt.textContent = t;
+        typeSelect.appendChild(opt);
+    }
+
+    for (const n of names) {
+        const opt = document.createElement('option');
+        opt.value = n;
+        opt.textContent = n;
+        sessionSelect.appendChild(opt);
+    }
+
+    daySelect.addEventListener('change', renderSessions);
+    typeSelect.addEventListener('change', renderSessions);
+    sessionSelect.addEventListener('change', renderSessions);
+}
+
+function renderSessions() {
+    const dayFilter = document.getElementById('day-select').value;
+    const typeFilter = document.getElementById('type-select').value;
+    const sessionFilter = document.getElementById('session-select').value;
+
+    const container = document.getElementById('sessions');
+    container.innerHTML = '';
+
+    const filtered = sessionsData.filter(s =>
+        (dayFilter === 'all' || s.day === dayFilter) &&
+        (typeFilter === 'all' || s.type === typeFilter) &&
+        (sessionFilter === 'all' || s.session === sessionFilter)
+    );
+
+    if (!filtered.length) {
+        container.textContent = 'No sessions found.';
+        return;
+    }
+
+    for (const s of filtered) {
+        const sessionDiv = document.createElement('div');
+        sessionDiv.className = 'session';
+        const header = document.createElement('h3');
+        header.textContent = `${s.session} (${s.type}) - ${s.day}`;
+        sessionDiv.appendChild(header);
+        for (const p of s.presentations) {
+            const pDiv = document.createElement('div');
+            pDiv.className = 'presentation';
+            pDiv.textContent = `${p.time} - ${p.presenter}: ${p.title}`;
+            sessionDiv.appendChild(pDiv);
+        }
+        container.appendChild(sessionDiv);
+    }
+}
+
+window.addEventListener('DOMContentLoaded', loadData);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ASSC 2025 Program Explorer</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>ASSC 2025 Program Explorer</h1>
+    <div id="filters">
+        <label for="day-select">Day:</label>
+        <select id="day-select">
+            <option value="all">All</option>
+        </select>
+
+        <label for="type-select">Type:</label>
+        <select id="type-select">
+            <option value="all">All</option>
+        </select>
+
+        <label for="session-select">Session:</label>
+        <select id="session-select">
+            <option value="all">All</option>
+        </select>
+    </div>
+    <div id="sessions"></div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/program.json
+++ b/program.json
@@ -1,0 +1,29 @@
+[
+  {
+    "session": "Session 1: Consciousness and Perception",
+    "day": "2025-06-14",
+    "type": "Talk",
+    "presentations": [
+      {"title": "The binding problem", "presenter": "Alice Example", "time": "09:00"},
+      {"title": "Visual illusions", "presenter": "Bob Example", "time": "09:30"}
+    ]
+  },
+  {
+    "session": "Session 2: Neural Correlates",
+    "day": "2025-06-14",
+    "type": "Poster",
+    "presentations": [
+      {"title": "Neural circuits", "presenter": "Carol Example", "time": "12:00"},
+      {"title": "Brain mapping", "presenter": "Dave Example", "time": "12:30"}
+    ]
+  },
+  {
+    "session": "Session 3: Philosophy of Mind",
+    "day": "2025-06-15",
+    "type": "Talk",
+    "presentations": [
+      {"title": "Qualia question", "presenter": "Eve Example", "time": "10:00"},
+      {"title": "Free will debate", "presenter": "Frank Example", "time": "10:30"}
+    ]
+  }
+]

--- a/style.css
+++ b/style.css
@@ -1,0 +1,33 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    background-color: #f2f2f2;
+}
+
+h1 {
+    text-align: center;
+}
+
+#filters {
+    margin-bottom: 20px;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+
+#sessions {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.session {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.presentation {
+    margin-left: 15px;
+}


### PR DESCRIPTION
## Summary
- add a small single-page application to browse sample session data
- include example data in `program.json`
- provide minimal styling and filtering in JS
- update README with usage instructions

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686512abf9648323ae4b39113ec9cbb2